### PR TITLE
Update init_python.sh

### DIFF
--- a/src/init/init_python.sh
+++ b/src/init/init_python.sh
@@ -27,8 +27,8 @@ else
 fi
 
 echo -en "Installing Python3 dependencies... "
-$PIP install --upgrade pip  2>&1 > /dev/null
-$PIP install ipfshttpclient web3 psutil --upgrade 2>&1 > /dev/null
+$PIP install --upgrade pip --no-warn-script-location 2>&1 > /dev/null
+$PIP install ipfshttpclient==0.8.0a2 web3 psutil --upgrade --no-warn-script-location 2>&1 > /dev/null
 echo "done"
 
 [ -d certs ] || mkdir certs


### PR DESCRIPTION
1. Upgrade ipfshttpclient to version 0.8.0a2 according to web3 requirements.
2. Add --no-warn-script-location to pip installation to avoid user's confusion.